### PR TITLE
Add Azure One Key Deployment Script

### DIFF
--- a/deployment/azure/README.md
+++ b/deployment/azure/README.md
@@ -1,0 +1,22 @@
+# Quick Deploy on Azure Container Apps
+
+This guide provides a quick way to deploy the SDCB Chats application on Azure Container Apps using Bicep templates. It automates the deployment process, including creating necessary resources like storage accounts and container apps.
+
+Note: For manual deployment, refer to the [manual deployment guide](https://edi.wang/post/2025/7/25/deploy-sdcb-chats-on-azure-container-apps).
+
+Prerequisites:
+- Azure CLI installed and logged in
+- Azure Bicep CLI installed
+
+## Run the following commands in your terminal:
+
+e.g. Deploy to a resource group named `sdcbchats-test996-rg` in the `japaneast` region.
+
+```powershell
+az group create --name sdcbchats-test996-rg --location japaneast
+az deployment group create --resource-group sdcbchats-test996-rg --template-file main.bicep --parameters storageAccountName=sdcbchatsstorage2996
+```
+
+## Access the deployed application
+
+After the deployment is complete, you can access the application using the URL provided in the Azure Portal under the Container Apps resource.

--- a/deployment/azure/main.bicep
+++ b/deployment/azure/main.bicep
@@ -1,0 +1,160 @@
+@description('Name of the storage account (must be globally unique)')
+param storageAccountName string = 'sdcbchatsstorage1069'
+
+@description('Location for all resources')
+param location string = resourceGroup().location
+
+@description('Name of the file share')
+param fileShareName string = 'sdcbchatsfileshare'
+
+@description('Name for the Container Apps Environment')
+param envName string = 'ca-env'
+
+@description('Name for the Container App')
+param containerAppName string = 'sdcbchats-app'
+
+// Storage Account
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: storageAccountName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+// Storage Share
+resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2022-09-01' = {
+  name: '${storageAccount.name}/default/${fileShareName}'
+  properties: {
+    shareQuota: 100 // in GB
+    accessTier: 'TransactionOptimized'
+  }
+}
+
+// Log Analytics for Container Apps Environment
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: '${envName}-log'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+// Container Apps Environment
+resource containerAppEnv 'Microsoft.App/managedEnvironments@2023-05-01' = {
+  name: envName
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
+    }
+  }
+}
+
+// Get Storage Key for mounting File Share
+var storageAccountKey = storageAccount.listKeys().keys[0].value
+
+resource meStorage 'Microsoft.App/managedEnvironments/storages@2023-05-01' = {
+  parent: containerAppEnv
+  name: '${storageAccountName}fileshare'
+  properties: {
+    azureFile: {
+      accountName: storageAccountName
+      shareName: fileShareName
+      accountKey: storageAccountKey
+      accessMode: 'ReadWrite'
+    }
+  }
+}
+
+resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
+  name: containerAppName
+  location: location
+  properties: {
+    managedEnvironmentId: containerAppEnv.id
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8080
+        transport: 'auto'
+        allowInsecure: false
+      }
+      secrets: [
+        {
+          name: 'storage-account-key'
+          value: storageAccountKey
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'sdcbchats-app'
+          image: 'docker.io/sdcb/chats:latest'
+          resources: {
+            cpu: 2
+            memory: '4Gi'
+          }
+          env: [
+            {
+              name: 'DBType'
+              value: 'sqlite'
+            }
+            {
+              name: 'ConnectionStrings__ChatsDB'
+              value: 'Data Source=./AppData/chats.db'
+            }
+            // {
+            //   name: 'JwtSecretKey'
+            //   value: 'your_jwt_secret_key_here'
+            // }
+          ]
+          volumeMounts: [
+            {
+              volumeName: 'appdata'
+              mountPath: '/app/AppData'
+            }
+          ]
+        }
+      ]
+      volumes: [
+        {
+          name: 'appdata'
+          storageType: 'AzureFile'
+          storageName: meStorage.name
+          mountOptions: 'nobrl'
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+        rules: [
+          {
+            name: 'http-rule'
+            http: {
+              metadata: {
+                concurrentRequests: '10'
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+output storageAccountName string = storageAccount.name
+output fileShareName string = fileShare.name
+output containerAppFqdn string = containerApp.properties.configuration.ingress.fqdn

--- a/doc/en-US/azure-bicep.md
+++ b/doc/en-US/azure-bicep.md
@@ -1,0 +1,24 @@
+# Quick Deploy on Azure Container Apps
+
+[中文](../zh-CN/azure-bicep.md) | **English**
+
+This guide provides a quick way to deploy the SDCB Chats application on Azure Container Apps using Bicep templates. It automates the deployment process, including creating necessary resources like storage accounts and container apps.
+
+Note: For manual deployment, refer to the [manual deployment guide](https://edi.wang/post/2025/7/25/deploy-sdcb-chats-on-azure-container-apps).
+
+Prerequisites:
+- Azure CLI installed and logged in
+- Azure Bicep CLI installed
+
+## Run the following commands in your terminal:
+
+e.g. Deploy to a resource group named `sdcbchats-rg` in the `japaneast` region.
+
+```powershell
+az group create --name sdcbchats-rg --location japaneast
+az deployment group create --resource-group sdcbchats-rg --template-file main.bicep --parameters storageAccountName=sdcbchatsstorage2996
+```
+
+## Access the deployed application
+
+After the deployment is complete, you can access the application using the URL provided in the Azure Portal under the Container Apps resource.

--- a/doc/zh-CN/azure-bicep.md
+++ b/doc/zh-CN/azure-bicep.md
@@ -1,0 +1,24 @@
+# 在 Azure 容器应用上快速部署
+
+**中文** | [English](../en-US/azure-bicep.md)
+
+本指南提供了使用 Bicep 模板在 Azure 容器应用上快速部署 SDCB Chats 应用的方法。它自动化了部署流程，包括创建存储账户和容器应用等必要资源。
+
+注意：如需手动部署，请参考[手动部署指南](https://edi.wang/post/2025/7/25/deploy-sdcb-chats-on-azure-container-apps)。
+
+前置条件：
+- 已安装并登录 Azure CLI
+- 已安装 Azure Bicep CLI
+
+## 在终端中运行以下命令：
+
+例如，将应用部署到 `japaneast` 区域的资源组 `sdcbchats-rg`。
+
+```powershell
+az group create --name sdcbchats-rg --location japaneast
+az deployment group create --resource-group sdcbchats-rg --template-file main.bicep --parameters storageAccountName=sdcbchatsstorage2996
+```
+
+## 访问已部署的应用
+
+部署完成后，可在 Azure 门户的容器应用资源下找到应用的访问 URL。

--- a/eng/azure/main.bicep
+++ b/eng/azure/main.bicep
@@ -1,0 +1,160 @@
+@description('Name of the storage account (must be globally unique)')
+param storageAccountName string = 'sdcbchatsstorage1069'
+
+@description('Location for all resources')
+param location string = resourceGroup().location
+
+@description('Name of the file share')
+param fileShareName string = 'sdcbchatsfileshare'
+
+@description('Name for the Container Apps Environment')
+param envName string = 'ca-env'
+
+@description('Name for the Container App')
+param containerAppName string = 'sdcbchats-app'
+
+// Storage Account
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: storageAccountName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+// Storage Share
+resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2022-09-01' = {
+  name: '${storageAccount.name}/default/${fileShareName}'
+  properties: {
+    shareQuota: 100 // in GB
+    accessTier: 'TransactionOptimized'
+  }
+}
+
+// Log Analytics for Container Apps Environment
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: '${envName}-log'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+// Container Apps Environment
+resource containerAppEnv 'Microsoft.App/managedEnvironments@2023-05-01' = {
+  name: envName
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
+    }
+  }
+}
+
+// Get Storage Key for mounting File Share
+var storageAccountKey = storageAccount.listKeys().keys[0].value
+
+resource meStorage 'Microsoft.App/managedEnvironments/storages@2023-05-01' = {
+  parent: containerAppEnv
+  name: '${storageAccountName}fileshare'
+  properties: {
+    azureFile: {
+      accountName: storageAccountName
+      shareName: fileShareName
+      accountKey: storageAccountKey
+      accessMode: 'ReadWrite'
+    }
+  }
+}
+
+resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
+  name: containerAppName
+  location: location
+  properties: {
+    managedEnvironmentId: containerAppEnv.id
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8080
+        transport: 'auto'
+        allowInsecure: false
+      }
+      secrets: [
+        {
+          name: 'storage-account-key'
+          value: storageAccountKey
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'sdcbchats-app'
+          image: 'docker.io/sdcb/chats:latest'
+          resources: {
+            cpu: 2
+            memory: '4Gi'
+          }
+          env: [
+            {
+              name: 'DBType'
+              value: 'sqlite'
+            }
+            {
+              name: 'ConnectionStrings__ChatsDB'
+              value: 'Data Source=./AppData/chats.db'
+            }
+            // {
+            //   name: 'JwtSecretKey'
+            //   value: 'your_jwt_secret_key_here'
+            // }
+          ]
+          volumeMounts: [
+            {
+              volumeName: 'appdata'
+              mountPath: '/app/AppData'
+            }
+          ]
+        }
+      ]
+      volumes: [
+        {
+          name: 'appdata'
+          storageType: 'AzureFile'
+          storageName: meStorage.name
+          mountOptions: 'nobrl'
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+        rules: [
+          {
+            name: 'http-rule'
+            http: {
+              metadata: {
+                concurrentRequests: '10'
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+output storageAccountName string = storageAccount.name
+output fileShareName string = fileShare.name
+output containerAppFqdn string = containerApp.properties.configuration.ingress.fqdn


### PR DESCRIPTION
This pull request introduces a streamlined approach for deploying the SDCB Chats application on Azure Container Apps using Bicep templates. It includes documentation updates and a new `main.bicep` file that automates resource creation, such as storage accounts, file shares, container apps, and managed environments. Below are the most important changes grouped by theme:

### Documentation for Deployment:
- **`deployment/azure/README.md`:** Added a quick deployment guide for Azure Container Apps using Bicep templates. It outlines prerequisites, commands for deployment, and instructions for accessing the deployed application.

### Infrastructure Automation:
- **`deployment/azure/main.bicep`:** Created a Bicep template to automate the deployment of Azure resources, including:
  - Storage account creation with HTTPS-only traffic and hot access tier.
  - File share creation with a quota of 100GB for application data storage.
  - Log Analytics workspace setup for monitoring container apps.
  - Managed environment configuration for container apps, including app logs and storage integration.
  - Container app setup with scaling rules, environment variables, and Azure File volume mounts for persistent storage.