### PR TITLE
 feat(be): 支持同名模型按用户维度轮询负载均衡

### DIFF
--- a/src/BE/web/Program.cs
+++ b/src/BE/web/Program.cs
@@ -89,6 +89,7 @@ public class Program
         builder.Services.AddSingleton<FileImageInfoService>();
         builder.Services.AddSingleton<AsyncClientInfoManager>();
         builder.Services.AddSingleton<AsyncCacheUsageManager>();
+        builder.Services.AddSingleton<UserModelLoadBalancer>();
         builder.Services.AddSingleton<GitHubReleaseChecker>();
 
         builder.Services.AddScoped<CurrentUser>();

--- a/src/BE/web/Services/UserModelLoadBalancer.cs
+++ b/src/BE/web/Services/UserModelLoadBalancer.cs
@@ -1,0 +1,30 @@
+using Chats.DB;
+using System.Collections.Concurrent;
+
+namespace Chats.BE.Services;
+
+public class UserModelLoadBalancer
+{
+    private static readonly ConcurrentDictionary<string, long> _counters = new();
+
+    public UserModel Select(int userId, string modelName, UserModel[] candidates)
+    {
+        ArgumentNullException.ThrowIfNull(modelName);
+        ArgumentNullException.ThrowIfNull(candidates);
+
+        if (candidates.Length == 0)
+        {
+            throw new ArgumentException("No candidate models available.", nameof(candidates));
+        }
+
+        if (candidates.Length == 1)
+        {
+            return candidates[0];
+        }
+
+        string key = $"{userId}:{modelName}";
+        long next = _counters.AddOrUpdate(key, 0, static (_, current) => current == long.MaxValue ? 0 : current + 1);
+        int index = (int)(next % candidates.Length);
+        return candidates[index];
+    }
+}


### PR DESCRIPTION
  - 新增 UserModelLoadBalancer，按 userId:modelName 维护轮询计数
  - UserModelManager 从单条命中改为查询同名候选集合并按 ModelId 排序
  - 多候选时使用负载均衡器返回模型，单候选保持原行为不变
  - 在 Program 中注册 UserModelLoadBalancer（Singleton）