### PR TITLE
fix: tool_calls error

### DIFF
--- a/src/BE/tests/Chats.BE.UnitTest/ChatServices/ChatCompletions/EnsureToolResponseIntegrityTests.cs
+++ b/src/BE/tests/Chats.BE.UnitTest/ChatServices/ChatCompletions/EnsureToolResponseIntegrityTests.cs
@@ -128,4 +128,81 @@ public class EnsureToolResponseIntegrityTests
         var missing = result[3].Contents.OfType<NeutralToolCallResponseContent>().First();
         Assert.Equal("call_2", missing.ToolCallId);
     }
+
+    [Fact]
+    public void OrphanedToolResponse_BeforeAnyAssistant_Removed()
+    {
+        IList<NeutralMessage> messages = [
+            NeutralMessage.FromTool(
+                NeutralToolCallResponseContent.Create("call_1", "result")),
+            NeutralMessage.FromUserText("hello"),
+        ];
+
+        IList<NeutralMessage> result = NeutralConversions.EnsureToolResponseIntegrity(messages);
+        Assert.Single(result);
+        Assert.Equal(NeutralChatRole.User, result[0].Role);
+    }
+
+    [Fact]
+    public void OrphanedToolResponse_AfterUser_Removed()
+    {
+        IList<NeutralMessage> messages = [
+            NeutralMessage.FromUserText("hello"),
+            NeutralMessage.FromTool(
+                NeutralToolCallResponseContent.Create("call_1", "result")),
+            NeutralMessage.FromAssistantText("hi"),
+        ];
+
+        IList<NeutralMessage> result = NeutralConversions.EnsureToolResponseIntegrity(messages);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(NeutralChatRole.User, result[0].Role);
+        Assert.Equal(NeutralChatRole.Assistant, result[1].Role);
+    }
+
+    [Fact]
+    public void OrphanedToolResponse_WrongCallId_Removed()
+    {
+        IList<NeutralMessage> messages = [
+            NeutralMessage.FromAssistant(
+                NeutralToolCallContent.Create("call_A", "func", "{}")),
+            NeutralMessage.FromTool(
+                NeutralToolCallResponseContent.Create("call_A", "ok")),
+            NeutralMessage.FromTool(
+                NeutralToolCallResponseContent.Create("call_X", "orphaned")),
+        ];
+
+        IList<NeutralMessage> result = NeutralConversions.EnsureToolResponseIntegrity(messages);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(NeutralChatRole.Assistant, result[0].Role);
+        Assert.Equal(NeutralChatRole.Tool, result[1].Role);
+        var resp = result[1].Contents.OfType<NeutralToolCallResponseContent>().First();
+        Assert.Equal("call_A", resp.ToolCallId);
+    }
+
+    [Fact]
+    public void Mixed_MissingAndOrphaned_BothFixed()
+    {
+        IList<NeutralMessage> messages = [
+            NeutralMessage.FromAssistant(
+                NeutralToolCallContent.Create("call_A", "func", "{}"),
+                NeutralToolCallContent.Create("call_B", "func", "{}")),
+            NeutralMessage.FromTool(
+                NeutralToolCallResponseContent.Create("call_A", "ok")),
+            // call_B missing, call_X orphaned
+            NeutralMessage.FromTool(
+                NeutralToolCallResponseContent.Create("call_X", "orphaned")),
+        ];
+
+        IList<NeutralMessage> result = NeutralConversions.EnsureToolResponseIntegrity(messages);
+        Assert.Equal(3, result.Count);
+
+        // assistant, then tool(call_B, ""), then tool(call_A)
+        Assert.Equal(NeutralChatRole.Tool, result[1].Role);
+        Assert.Equal(NeutralChatRole.Tool, result[2].Role);
+        var ids = result.Skip(1).SelectMany(m => m.Contents.OfType<NeutralToolCallResponseContent>())
+            .Select(r => r.ToolCallId).ToList();
+        Assert.Contains("call_A", ids);
+        Assert.Contains("call_B", ids);
+        Assert.DoesNotContain("call_X", ids);
+    }
 }

--- a/src/BE/tests/Chats.BE.UnitTest/ChatServices/ChatCompletions/EnsureToolResponseIntegrityTests.cs
+++ b/src/BE/tests/Chats.BE.UnitTest/ChatServices/ChatCompletions/EnsureToolResponseIntegrityTests.cs
@@ -1,0 +1,131 @@
+using Chats.BE.Services.Models.Neutral;
+
+namespace Chats.BE.UnitTest.ChatServices.ChatCompletions;
+
+public class EnsureToolResponseIntegrityTests
+{
+    [Fact]
+    public void NoToolCalls_ReturnsOriginal()
+    {
+        IList<NeutralMessage> messages = [
+            NeutralMessage.FromUserText("hello"),
+            NeutralMessage.FromAssistantText("hi"),
+        ];
+
+        IList<NeutralMessage> result = NeutralConversions.EnsureToolResponseIntegrity(messages);
+        Assert.Same(messages, result);
+    }
+
+    [Fact]
+    public void AllResponsesPresent_ReturnsOriginal()
+    {
+        IList<NeutralMessage> messages = [
+            NeutralMessage.FromAssistant(
+                NeutralToolCallContent.Create("call_1", "func", "{}")),
+            NeutralMessage.FromTool(
+                NeutralToolCallResponseContent.Create("call_1", "result")),
+        ];
+
+        IList<NeutralMessage> result = NeutralConversions.EnsureToolResponseIntegrity(messages);
+        Assert.Same(messages, result);
+    }
+
+    [Fact]
+    public void MissingResponse_AddsEmptyResponse()
+    {
+        IList<NeutralMessage> messages = [
+            NeutralMessage.FromAssistant(
+                NeutralToolCallContent.Create("call_1", "func", "{}")),
+            NeutralMessage.FromUserText("next"),
+        ];
+
+        IList<NeutralMessage> result = NeutralConversions.EnsureToolResponseIntegrity(messages);
+        Assert.NotSame(messages, result);
+        Assert.Equal(3, result.Count);
+
+        Assert.Equal(NeutralChatRole.Assistant, result[0].Role);
+        Assert.Equal(NeutralChatRole.Tool, result[1].Role);
+        Assert.Equal(NeutralChatRole.User, result[2].Role);
+
+        var toolResponse = result[1].Contents.OfType<NeutralToolCallResponseContent>().First();
+        Assert.Equal("call_1", toolResponse.ToolCallId);
+        Assert.Equal("", toolResponse.Response);
+    }
+
+    [Fact]
+    public void PartialMissing_AddsOnlyMissing()
+    {
+        IList<NeutralMessage> messages = [
+            NeutralMessage.FromAssistant(
+                NeutralToolCallContent.Create("call_1", "func1", "{}"),
+                NeutralToolCallContent.Create("call_2", "func2", "{}")),
+            NeutralMessage.FromTool(
+                NeutralToolCallResponseContent.Create("call_1", "result1")),
+        ];
+
+        IList<NeutralMessage> result = NeutralConversions.EnsureToolResponseIntegrity(messages);
+        Assert.NotSame(messages, result);
+        Assert.Equal(3, result.Count);
+
+        // Inserted missing response is at index 1 (right after assistant)
+        Assert.Equal(NeutralChatRole.Tool, result[1].Role);
+        var missingResponse = result[1].Contents.OfType<NeutralToolCallResponseContent>().First();
+        Assert.Equal("call_2", missingResponse.ToolCallId);
+        Assert.Equal("", missingResponse.Response);
+
+        // Original response is at index 2
+        Assert.Equal(NeutralChatRole.Tool, result[2].Role);
+        var existingResponse = result[2].Contents.OfType<NeutralToolCallResponseContent>().First();
+        Assert.Equal("call_1", existingResponse.ToolCallId);
+        Assert.Equal("result1", existingResponse.Response);
+    }
+
+    [Fact]
+    public void EmptyMessages_ReturnsOriginal()
+    {
+        IList<NeutralMessage> messages = [];
+        IList<NeutralMessage> result = NeutralConversions.EnsureToolResponseIntegrity(messages);
+        Assert.Same(messages, result);
+    }
+
+    [Fact]
+    public void AllResponsesMissing_AddsAll()
+    {
+        IList<NeutralMessage> messages = [
+            NeutralMessage.FromAssistant(
+                NeutralToolCallContent.Create("call_1", "func1", "{}"),
+                NeutralToolCallContent.Create("call_2", "func2", "{}")),
+        ];
+
+        IList<NeutralMessage> result = NeutralConversions.EnsureToolResponseIntegrity(messages);
+        Assert.NotSame(messages, result);
+        Assert.Equal(3, result.Count);
+
+        var ids = result.Skip(1).SelectMany(m => m.Contents.OfType<NeutralToolCallResponseContent>())
+            .Select(r => r.ToolCallId).ToList();
+        Assert.Equal(["call_1", "call_2"], ids);
+    }
+
+    [Fact]
+    public void MultipleAssistantMessages_EachValidated()
+    {
+        IList<NeutralMessage> messages = [
+            // First turn: complete
+            NeutralMessage.FromAssistant(
+                NeutralToolCallContent.Create("call_1", "func", "{}")),
+            NeutralMessage.FromTool(
+                NeutralToolCallResponseContent.Create("call_1", "ok")),
+            // Second turn: missing response
+            NeutralMessage.FromAssistant(
+                NeutralToolCallContent.Create("call_2", "func", "{}")),
+        ];
+
+        IList<NeutralMessage> result = NeutralConversions.EnsureToolResponseIntegrity(messages);
+        Assert.Equal(4, result.Count);
+
+        Assert.Equal(NeutralChatRole.Assistant, result[2].Role);
+        Assert.Equal(NeutralChatRole.Tool, result[3].Role);
+        var missing = result[3].Contents.OfType<NeutralToolCallResponseContent>().First();
+        Assert.Equal("call_2", missing.ToolCallId);
+    }
+}

--- a/src/BE/web/Services/Models/Neutral/Conversions/NeutralConversions.cs
+++ b/src/BE/web/Services/Models/Neutral/Conversions/NeutralConversions.cs
@@ -29,7 +29,68 @@ public static class NeutralConversions
                 result.Add(message);
             }
         }
-        return result;
+        return EnsureToolResponseIntegrity(result);
+    }
+
+    /// <summary>
+    /// Ensures all tool_calls in assistant messages have corresponding tool response messages.
+    /// Adds empty tool responses for any missing tool_call_ids to prevent upstream API errors.
+    /// This handles cases where tool messages are silently dropped during parsing (e.g., missing tool_call_id).
+    /// </summary>
+    public static IList<NeutralMessage> EnsureToolResponseIntegrity(IList<NeutralMessage> messages)
+    {
+        if (messages.Count == 0) return messages;
+
+        // Quick check: if no assistant messages with tool_calls, nothing to do
+        bool hasToolCalls = false;
+        for (int i = 0; i < messages.Count; i++)
+        {
+            if (messages[i].Role == NeutralChatRole.Assistant &&
+                messages[i].Contents.Any(c => c is NeutralToolCallContent))
+            {
+                hasToolCalls = true;
+                break;
+            }
+        }
+        if (!hasToolCalls) return messages;
+
+        List<NeutralMessage> result = new(messages.Count);
+        bool modified = false;
+
+        for (int i = 0; i < messages.Count; i++)
+        {
+            result.Add(messages[i]);
+
+            if (messages[i].Role != NeutralChatRole.Assistant) continue;
+
+            List<NeutralToolCallContent> toolCalls = messages[i].Contents.OfType<NeutralToolCallContent>().ToList();
+            if (toolCalls.Count == 0) continue;
+
+            // Collect tool_call_ids from immediately following tool messages
+            HashSet<string> respondedIds = new();
+            int j = i + 1;
+            while (j < messages.Count && messages[j].Role == NeutralChatRole.Tool)
+            {
+                foreach (NeutralToolCallResponseContent resp in messages[j].Contents.OfType<NeutralToolCallResponseContent>())
+                {
+                    respondedIds.Add(resp.ToolCallId);
+                }
+                j++;
+            }
+
+            // Find missing tool_call_ids and add empty responses
+            foreach (NeutralToolCallContent tc in toolCalls)
+            {
+                if (!respondedIds.Contains(tc.Id))
+                {
+                    modified = true;
+                    result.Add(NeutralMessage.FromTool(
+                        NeutralToolCallResponseContent.Create(tc.Id, "")));
+                }
+            }
+        }
+
+        return modified ? result : messages;
     }
 
     /// <summary>

--- a/src/BE/web/Services/Models/Neutral/Conversions/NeutralConversions.cs
+++ b/src/BE/web/Services/Models/Neutral/Conversions/NeutralConversions.cs
@@ -33,59 +33,93 @@ public static class NeutralConversions
     }
 
     /// <summary>
-    /// Ensures all tool_calls in assistant messages have corresponding tool response messages.
-    /// Adds empty tool responses for any missing tool_call_ids to prevent upstream API errors.
-    /// This handles cases where tool messages are silently dropped during parsing (e.g., missing tool_call_id).
+    /// Ensures tool_calls/tool_response chain integrity in the message list.
+    /// 1. Adds empty tool responses for any missing tool_call_ids (orphaned tool_calls).
+    /// 2. Removes tool response messages that don't follow an assistant message with matching tool_calls (orphaned responses).
+    /// This handles cases where messages are silently dropped during parsing.
     /// </summary>
     public static IList<NeutralMessage> EnsureToolResponseIntegrity(IList<NeutralMessage> messages)
     {
         if (messages.Count == 0) return messages;
 
-        // Quick check: if no assistant messages with tool_calls, nothing to do
-        bool hasToolCalls = false;
+        // Quick check: any tool interaction at all?
+        bool hasToolInteraction = false;
         for (int i = 0; i < messages.Count; i++)
         {
-            if (messages[i].Role == NeutralChatRole.Assistant &&
-                messages[i].Contents.Any(c => c is NeutralToolCallContent))
+            if (messages[i].Role == NeutralChatRole.Tool ||
+                (messages[i].Role == NeutralChatRole.Assistant && messages[i].Contents.Any(c => c is NeutralToolCallContent)))
             {
-                hasToolCalls = true;
+                hasToolInteraction = true;
                 break;
             }
         }
-        if (!hasToolCalls) return messages;
+        if (!hasToolInteraction) return messages;
 
         List<NeutralMessage> result = new(messages.Count);
         bool modified = false;
 
         for (int i = 0; i < messages.Count; i++)
         {
-            result.Add(messages[i]);
+            NeutralMessage msg = messages[i];
 
-            if (messages[i].Role != NeutralChatRole.Assistant) continue;
-
-            List<NeutralToolCallContent> toolCalls = messages[i].Contents.OfType<NeutralToolCallContent>().ToList();
-            if (toolCalls.Count == 0) continue;
-
-            // Collect tool_call_ids from immediately following tool messages
-            HashSet<string> respondedIds = new();
-            int j = i + 1;
-            while (j < messages.Count && messages[j].Role == NeutralChatRole.Tool)
+            // Remove orphaned tool responses: tool messages that don't follow an assistant with matching tool_calls
+            if (msg.Role == NeutralChatRole.Tool)
             {
-                foreach (NeutralToolCallResponseContent resp in messages[j].Contents.OfType<NeutralToolCallResponseContent>())
+                bool isOrphaned = true;
+                for (int r = result.Count - 1; r >= 0; r--)
                 {
-                    respondedIds.Add(resp.ToolCallId);
-                }
-                j++;
-            }
+                    if (result[r].Role == NeutralChatRole.Tool) continue; // skip over tool messages
 
-            // Find missing tool_call_ids and add empty responses
-            foreach (NeutralToolCallContent tc in toolCalls)
-            {
-                if (!respondedIds.Contains(tc.Id))
+                    if (result[r].Role == NeutralChatRole.Assistant)
+                    {
+                        // Check if any response ID matches this assistant's tool_calls
+                        HashSet<string> expectedIds = result[r].Contents
+                            .OfType<NeutralToolCallContent>()
+                            .Select(tc => tc.Id)
+                            .ToHashSet();
+                        isOrphaned = !msg.Contents
+                            .OfType<NeutralToolCallResponseContent>()
+                            .Any(resp => expectedIds.Contains(resp.ToolCallId));
+                    }
+                    break; // only check the nearest non-tool preceding message
+                }
+
+                if (isOrphaned)
                 {
                     modified = true;
-                    result.Add(NeutralMessage.FromTool(
-                        NeutralToolCallResponseContent.Create(tc.Id, "")));
+                    continue;
+                }
+            }
+
+            result.Add(msg);
+
+            // For assistant messages with tool_calls, add missing tool responses
+            if (msg.Role == NeutralChatRole.Assistant)
+            {
+                List<NeutralToolCallContent> toolCalls = msg.Contents.OfType<NeutralToolCallContent>().ToList();
+                if (toolCalls.Count == 0) continue;
+
+                // Collect tool_call_ids from immediately following tool messages in the original list
+                HashSet<string> respondedIds = new();
+                int j = i + 1;
+                while (j < messages.Count && messages[j].Role == NeutralChatRole.Tool)
+                {
+                    foreach (NeutralToolCallResponseContent resp in messages[j].Contents.OfType<NeutralToolCallResponseContent>())
+                    {
+                        respondedIds.Add(resp.ToolCallId);
+                    }
+                    j++;
+                }
+
+                // Add empty responses for missing tool_call_ids
+                foreach (NeutralToolCallContent tc in toolCalls)
+                {
+                    if (!respondedIds.Contains(tc.Id))
+                    {
+                        modified = true;
+                        result.Add(NeutralMessage.FromTool(
+                            NeutralToolCallResponseContent.Create(tc.Id, "")));
+                    }
                 }
             }
         }


### PR DESCRIPTION
fix two problem:
{
	"error": {
		"message": "An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: call_ctiGXrgM0r61c6nkf2v7zbKb",
		"type": "invalid_request_error",
		"param": "messages.[57].role",
		"code": null
	}
}
and
{
	"error": {
		"message": "Invalid parameter: messages with role 'tool' must be a response to a preceeding message with 'tool_calls'.",
		"type": "invalid_request_error",
		"param": "messages.[59].role",
		"code": null
	}
}