### PR TITLE
Add Requesty as a provider

### DIFF
--- a/doc/en-US/model-providers.md
+++ b/doc/en-US/model-providers.md
@@ -29,6 +29,7 @@ Sdcb Chats supports 22+ mainstream AI model providers. Here is the complete list
 | 20  | Anthropic        | [2025-11-24](https://github.com/sdcb/chats/commit/22ebef98) | ✅                    |
 | 21  | Xiaomi Mimo      | [2025-12-17](https://github.com/sdcb/chats/commit/026f1a4e) | ✅                    |
 | 22  | Novita AI        | [2026-03-13](https://github.com/sdcb/chats/commit/cecfc66d) | ✅                    |
+| 23  | Requesty         | [2026-07-04](https://requesty.ai)                           | ❓                    |
 
 ## Notes
 

--- a/doc/zh-CN/model-providers.md
+++ b/doc/zh-CN/model-providers.md
@@ -29,6 +29,7 @@ Sdcb Chats 支持 22+ 主流 AI 模型服务商，以下是完整列表：
 | 20  | Anthropic        | [2025-11-24](https://github.com/sdcb/chats/commit/22ebef98) | ✅        |
 | 21  | 小米Mimo         | [2025-12-17](https://github.com/sdcb/chats/commit/026f1a4e) | ✅        |
 | 22  | Novita AI        | [2026-03-13](https://github.com/sdcb/chats/commit/cecfc66d) | ✅        |
+| 23  | Requesty         | [2026-07-04](https://requesty.ai)                           | ❓        |
 
 ## 注意事项
 

--- a/src/BE/db/Enums/DBModelProvider.cs
+++ b/src/BE/db/Enums/DBModelProvider.cs
@@ -25,4 +25,5 @@ public enum DBModelProvider
     Anthropic = 20,
     Mimo = 21,
     Novita = 22,
+    Requesty = 23,
 }

--- a/src/BE/web/DB/ModelProviderInfo.cs
+++ b/src/BE/web/DB/ModelProviderInfo.cs
@@ -156,6 +156,12 @@ public static class ModelProviderInfo
              "https://api.novita.ai/openai",
              ""
          ),
+         [DBModelProvider.Requesty] = new(
+             DBModelProvider.Requesty,
+             "Requesty",
+             "https://router.requesty.ai/v1",
+             "rqsty-sk-***"
+         ),
      };
 
     private static readonly Dictionary<string, DBModelProvider> _nameToIdMap = _providers

--- a/src/BE/web/Program.cs
+++ b/src/BE/web/Program.cs
@@ -81,6 +81,7 @@ public class Program
         builder.Services.AddSingleton<Services.Models.ChatServices.OpenAI.SiliconFlowChatService>();
         builder.Services.AddSingleton<Services.Models.ChatServices.OpenAI.TokenPonyChatService>();
         builder.Services.AddSingleton<Services.Models.ChatServices.OpenAI.OpenRouterChatService>();
+        builder.Services.AddSingleton<Services.Models.ChatServices.OpenAI.RequestyChatService>();
         builder.Services.AddSingleton<Services.Models.ChatServices.OpenAI.Special.ResponseApiService>();
         builder.Services.AddSingleton<Services.Models.ChatServices.OpenAI.Special.AzureResponseApiService>();
         builder.Services.AddSingleton<Services.Models.ChatServices.OpenAI.MiniMaxChatService>();

--- a/src/BE/web/Services/Models/ChatServices/ChatFactory.cs
+++ b/src/BE/web/Services/Models/ChatServices/ChatFactory.cs
@@ -46,6 +46,7 @@ public class ChatFactory(ILogger<ChatFactory> logger, IServiceProvider sp)
                 DBModelProvider.SiliconFlow => sp.GetRequiredService<SiliconFlowChatService>(),
              DBModelProvider.TokenPony => sp.GetRequiredService<TokenPonyChatService>(),
              DBModelProvider.OpenRouter => sp.GetRequiredService<OpenRouterChatService>(),
+             DBModelProvider.Requesty => sp.GetRequiredService<RequestyChatService>(),
              DBModelProvider.Novita => sp.GetRequiredService<NovitaChatService>(),
              _ => sp.GetRequiredService<ChatCompletionService>() // Fallback to OpenAI-compatible
             },

--- a/src/BE/web/Services/Models/ChatServices/OpenAI/RequestyChatService.cs
+++ b/src/BE/web/Services/Models/ChatServices/OpenAI/RequestyChatService.cs
@@ -1,0 +1,13 @@
+using Chats.DB;
+
+namespace Chats.BE.Services.Models.ChatServices.OpenAI;
+
+public class RequestyChatService(IHttpClientFactory httpClientFactory, HostUrlService hostUrlService) : ChatCompletionService(httpClientFactory)
+{
+    protected override void AddAuthorizationHeader(HttpRequestMessage request, ModelKeySnapshot modelKey)
+    {
+        base.AddAuthorizationHeader(request, modelKey);
+        request.Headers.Add("X-Title", "Sdcb Chats");
+        request.Headers.Add("HTTP-Referer", hostUrlService.GetFEUrl());
+    }
+}

--- a/src/FE/public/logos/requesty.svg
+++ b/src/FE/public/logos/requesty.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Neutral placeholder icon for Requesty (generic router glyph). Not the official Requesty logo. -->
+  <rect x="3" y="14" width="18" height="7" rx="2"/>
+  <path d="M7 14V9a5 5 0 0 1 5-5 5 5 0 0 1 5 5v5"/>
+  <circle cx="8" cy="17.5" r="1"/>
+  <circle cx="12" cy="17.5" r="1"/>
+  <circle cx="16" cy="17.5" r="1"/>
+</svg>

--- a/src/FE/types/model.ts
+++ b/src/FE/types/model.ts
@@ -28,6 +28,7 @@ export enum DBModelProvider {
   Anthropic = 20,
   Mimo = 21,
   Novita = 22,
+  Requesty = 23,
 }
 
 export type FEModelProvider = {
@@ -135,6 +136,12 @@ export const feModelProviders: FEModelProvider[] = [
     id: DBModelProvider.Novita,
     name: 'Novita AI',
     icon: '/logos/novita.svg',
+  },
+  {
+    id: DBModelProvider.Requesty,
+    name: 'Requesty',
+    icon: '/logos/requesty.svg',
+    allowWebSearch: true,
   },
 ];
 


### PR DESCRIPTION
Adds Requesty as a provider, mirroring the existing OpenRouter provider end-to-end.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM router — base URL `https://router.requesty.ai/v1`, `provider/model` naming, `Authorization: Bearer` auth, optional `HTTP-Referer`/`X-Title` headers.

Changes:
- `src/BE/db/Enums/DBModelProvider.cs`: `Requesty = 23` (new unique value, appended).
- `src/BE/web/DB/ModelProviderInfo.cs`: a `Requesty` provider-info entry (`https://router.requesty.ai/v1`, `rqsty-sk-***`), mirroring OpenRouter's.
- `src/BE/web/Services/Models/ChatServices/OpenAI/RequestyChatService.cs` (new): extends `ChatCompletionService`, adds the `X-Title`/`HTTP-Referer` attribution headers (Requesty supports them) — without OpenRouter's provider-routing body fields, since Requesty is plain OpenAI-compatible.
- `src/BE/web/Services/Models/ChatServices/ChatFactory.cs`: `DBModelProvider.Requesty => RequestyChatService`.
- `src/BE/web/Program.cs`: DI registration mirroring OpenRouter.
- `src/FE/types/model.ts`: `Requesty = 23` in the FE enum + a `feModelProviders` entry.
- `doc/en-US/model-providers.md` + `doc/zh-CN/model-providers.md`: Requesty row.

Icon: `src/FE/public/logos/requesty.svg` is a neutral placeholder glyph (a generic router icon, not the official Requesty logo) — happy to swap for the real mark.

Note: I couldn't run `dotnet build` locally (no .NET toolchain on this machine), so please give it a build. Every OpenRouter reference was mirrored 1:1. A DB migration inserting provider id 23 (parallel to the OpenRouter migration) may be desired if you seed providers via SQL — happy to add it.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.