### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/src/BE/db/Enums/DBModelProvider.cs
+++ b/src/BE/db/Enums/DBModelProvider.cs
@@ -25,4 +25,5 @@ public enum DBModelProvider
     Anthropic = 20,
     Mimo = 21,
     Novita = 22,
+    LiteLLM = 23,
 }

--- a/src/BE/tests/Chats.BE.UnitTest/ChatServices/ChatCompletions/LiteLLMChatServiceTests.cs
+++ b/src/BE/tests/Chats.BE.UnitTest/ChatServices/ChatCompletions/LiteLLMChatServiceTests.cs
@@ -1,0 +1,21 @@
+using Chats.BE.Services.Models.ChatServices.OpenAI;
+
+namespace Chats.BE.UnitTest.ChatServices.ChatCompletions;
+
+public class LiteLLMChatServiceTests
+{
+    private sealed class DummyHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+
+    [Fact]
+    public void LiteLLMChatService_IsOpenAICompatible()
+    {
+        LiteLLMChatService svc = new(new DummyHttpClientFactory());
+
+        // LiteLLM Proxy speaks the OpenAI Chat Completions wire format, so the
+        // provider reuses the OpenAI-compatible transport and /models discovery.
+        Assert.IsAssignableFrom<ChatCompletionService>(svc);
+    }
+}

--- a/src/BE/web/DB/ModelProviderInfo.cs
+++ b/src/BE/web/DB/ModelProviderInfo.cs
@@ -156,6 +156,12 @@ public static class ModelProviderInfo
              "https://api.novita.ai/openai",
              ""
          ),
+        [DBModelProvider.LiteLLM] = new(
+            DBModelProvider.LiteLLM,
+            "LiteLLM",
+            "http://localhost:4000/v1",
+            "sk-"
+        ),
      };
 
     private static readonly Dictionary<string, DBModelProvider> _nameToIdMap = _providers

--- a/src/BE/web/Program.cs
+++ b/src/BE/web/Program.cs
@@ -92,6 +92,7 @@ public class Program
         builder.Services.AddSingleton<Services.Models.ChatServices.OpenAI.MimoChatService>();
         builder.Services.AddSingleton<Services.Models.ChatServices.OpenAI.MoonshotChatService>();
         builder.Services.AddSingleton<Services.Models.ChatServices.OpenAI.NovitaChatService>();
+        builder.Services.AddSingleton<Services.Models.ChatServices.OpenAI.LiteLLMChatService>();
 
         builder.Services.AddSingleton<Services.Models.ChatServices.OpenAI.Special.ImageGenerationService>();
         builder.Services.AddSingleton<Services.Models.ChatServices.OpenAI.Special.AzureImageGenerationService>();

--- a/src/BE/web/Services/Models/ChatServices/ChatFactory.cs
+++ b/src/BE/web/Services/Models/ChatServices/ChatFactory.cs
@@ -47,6 +47,7 @@ public class ChatFactory(ILogger<ChatFactory> logger, IServiceProvider sp)
              DBModelProvider.TokenPony => sp.GetRequiredService<TokenPonyChatService>(),
              DBModelProvider.OpenRouter => sp.GetRequiredService<OpenRouterChatService>(),
              DBModelProvider.Novita => sp.GetRequiredService<NovitaChatService>(),
+             DBModelProvider.LiteLLM => sp.GetRequiredService<LiteLLMChatService>(),
              _ => sp.GetRequiredService<ChatCompletionService>() // Fallback to OpenAI-compatible
             },
 

--- a/src/BE/web/Services/Models/ChatServices/OpenAI/LiteLLMChatService.cs
+++ b/src/BE/web/Services/Models/ChatServices/OpenAI/LiteLLMChatService.cs
@@ -1,0 +1,14 @@
+namespace Chats.BE.Services.Models.ChatServices.OpenAI;
+
+/// <summary>
+/// LiteLLM Chat Service.
+/// LiteLLM Proxy exposes an OpenAI-compatible Chat Completions API and a
+/// standard /models endpoint, so the base OpenAI-compatible transport and
+/// model auto-discovery are reused as-is. This first-class provider ships a
+/// sensible default host (http://localhost:4000/v1) so users can point Chats
+/// at a LiteLLM gateway and reach 100+ upstream providers (OpenAI, Anthropic,
+/// Bedrock, Vertex AI, Azure, etc.) through a single endpoint.
+/// </summary>
+public class LiteLLMChatService(IHttpClientFactory httpClientFactory) : ChatCompletionService(httpClientFactory)
+{
+}

--- a/src/FE/public/logos/litellm.svg
+++ b/src/FE/public/logos/litellm.svg
@@ -1,0 +1,16 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      path {
+        fill: #000;
+      }
+      @media ( prefers-color-scheme: dark ) {
+        path {
+          fill: #fff;
+        }
+      }
+    </style>
+  </defs>
+  <path d="M4 3h3.2v13.2H14V19H4V3Z" />
+  <path d="M13.4 3h3.2v13.2H23V19H13.4V3Z" opacity="0.55" />
+</svg>

--- a/src/FE/types/model.ts
+++ b/src/FE/types/model.ts
@@ -28,6 +28,7 @@ export enum DBModelProvider {
   Anthropic = 20,
   Mimo = 21,
   Novita = 22,
+  LiteLLM = 23,
 }
 
 export type FEModelProvider = {
@@ -143,6 +144,11 @@ export const feModelProviders: FEModelProvider[] = [
     id: DBModelProvider.Novita,
     name: 'Novita AI',
     icon: '/logos/novita.svg',
+  },
+  {
+    id: DBModelProvider.LiteLLM,
+    name: 'LiteLLM',
+    icon: '/logos/litellm.svg',
   },
 ];
 


### PR DESCRIPTION
## Summary

Adds **LiteLLM** as a first-class model provider. LiteLLM Proxy exposes an OpenAI-compatible Chat Completions API and a standard `/models` endpoint, so users can point Chats at a single LiteLLM gateway and reach 100+ upstream providers (OpenAI, Anthropic, Bedrock, Vertex AI, Azure, and more) through one endpoint, with API keys and routing centralized in the gateway.

## Changes

Backend:
- `src/BE/db/Enums/DBModelProvider.cs`: add `LiteLLM = 23`.
- `src/BE/web/DB/ModelProviderInfo.cs`: preset (name `LiteLLM`, default host `http://localhost:4000/v1`, secret hint `sk-`).
- `src/BE/web/Services/Models/ChatServices/OpenAI/LiteLLMChatService.cs`: new provider (subclass of `ChatCompletionService`; OpenAI-compatible transport + `/models` discovery reused).
- `src/BE/web/Services/Models/ChatServices/ChatFactory.cs`: dispatch `LiteLLM` under `OpenAIChatCompletion`.
- `src/BE/web/Program.cs`: register `LiteLLMChatService` in DI.

Frontend:
- `src/FE/types/model.ts`: enum value + `feModelProviders` entry.
- `src/FE/public/logos/litellm.svg`: provider logo (light/dark aware; please swap for the official mark if you prefer).

Tests:
- `src/BE/tests/Chats.BE.UnitTest/ChatServices/ChatCompletions/LiteLLMChatServiceTests.cs`.

15 lines across 5 existing files + 3 new files. Additive only; no existing provider touched.

## Tests

**1. Build + unit test (.NET 10 SDK):**
```
$ dotnet build src/BE/web/Chats.BE.csproj -c Debug
Build succeeded.
    0 Error(s)

$ dotnet test src/BE/tests/Chats.BE.UnitTest --filter FullyQualifiedName~LiteLLM
Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1 - Chats.BE.UnitTest.dll (net10.0)
```
The full web project compiles with the new enum, `ModelProviderInfo` preset, `LiteLLMChatService`, `ChatFactory` dispatch, and DI registration.

**2. Live end-to-end** against a LiteLLM Proxy (the three code paths `ChatCompletionService` uses), routing through two different upstreams:

**Model discovery (`ListModels` -> `GET /v1/models`):**
```
$ curl -s http://localhost:4000/v1/models -H "Authorization: Bearer $KEY"
{"data":[{"id":"gpt-4.1-mini",...},{"id":"gemini-2.5-flash",...}, ...]}
```

**Non-streaming chat (`gpt-4.1-mini` via LiteLLM):**
```
$ curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" \
    -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"Reply with exactly: CHATS_LITELLM_OK"}],"stream":false,"temperature":0}'
content:        CHATS_LITELLM_OK
finish_reason:  stop
usage:          {prompt_tokens: 18, completion_tokens: 7, total_tokens: 25}
```

**Streaming chat (`gemini-2.5-flash` via LiteLLM, SSE as `ChatStreamed` consumes):**
```
data: {"object":"chat.completion.chunk","model":"gemini-2.5-flash","choices":[{"delta":{"role":"assistant","content":"Hi"}}]}
data: {"object":"chat.completion.chunk","model":"gemini-2.5-flash","choices":[{"delta":{},"finish_reason":"stop"}]}
data: [DONE]
```